### PR TITLE
Ignore no-undef rule in typescript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/profico/eslint-plugin-profico.git"
   },
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "ESLint plugin and configurations by Profico",
   "main": "lib/index.js",
   "scripts": {

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -119,6 +119,14 @@ const recommended: Linter.Config = {
     "padding-line-between-statements": ["off"],
     quotes: ["off"],
   },
+  overrides: [
+    {
+      files: ["*.ts", "*.mts", "*.cts", "*.tsx"],
+      rules: {
+        "no-undef": "off",
+      },
+    },
+  ],
 };
 
 export default recommended;


### PR DESCRIPTION
Kontekst: https://typescript-eslint.io/troubleshooting/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors

tl;dr: eslint nije uvik u stanju skuzit globalne varijable iz 3rd party types paketa i typescript built-in tipova kad koristimo
```json
{
	"compilerOptions": {
		"lib": ["blabla"],
    	"types": ["blabla"]
	}
}
```

Nego ih moramo rucno definirat u eslint configu ovako:
```json
{
  "env": {
    "blabla": true,
  },
  "globals": {
    "blabla": "readonly",
  }
}
```

A buduci da typescript ionako vrsi type checking, on nam daje istu funkcionalnost ka taj rule, samo je puno pametniji oko toga kad nesto ima smisla. Tako da `no-undef` rule (nije nas, nego dolazi iz airbnb configa) samo stvara vise posla, a nema benefite.

Ovaj PR ga disablea samo za typescript fileove, tako da ce inace svejedno bit aktivan.